### PR TITLE
Update gitignore for client artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,8 @@ build/Release
 # Dependency directories
 server/node_modules
 server/package-lock.json
+client/node_modules/
+client/dist/
 jspm_packages/
 
 # Snowpack dependency directory (https://snowpack.dev/)


### PR DESCRIPTION
## Summary
- ignore `client/node_modules/` and `client/dist/` folders

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*
- `npm test` in `server` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684f2dd2cb74832390227d10678c4e3b