### PR TITLE
Use parameterized queries in helpers

### DIFF
--- a/server/db/helpers/__tests__/helpers.test.js
+++ b/server/db/helpers/__tests__/helpers.test.js
@@ -1,0 +1,41 @@
+const mockQuery = jest.fn(() => Promise.resolve({ rows: [], rowCount: 0 }));
+jest.mock('../../client', () => ({ query: mockQuery }));
+
+const { getPregnancyByUserId, updatePregnancies } = require('../pregnancy');
+const { updateJournal } = require('../users');
+const { updateWeeks } = require('../weeks');
+
+describe('database helper queries', () => {
+  beforeEach(() => {
+    mockQuery.mockClear();
+  });
+
+  test('getPregnancyByUserId uses parameter placeholder', async () => {
+    await getPregnancyByUserId(5);
+    expect(mockQuery).toHaveBeenCalledWith(
+      expect.stringContaining('WHERE preg.user_id = $1'),
+      [5]
+    );
+  });
+
+  test('updateJournal uses parameter placeholder', async () => {
+    await updateJournal(2, { username: 'user', journal: 'entry' });
+    const [sql, params] = mockQuery.mock.calls[0];
+    expect(sql).toContain('WHERE id = $3');
+    expect(params).toEqual(['user', 'entry', 2]);
+  });
+
+  test('updatePregnancies uses parameter placeholder', async () => {
+    await updatePregnancies(1, { age: 30 });
+    const [sql, params] = mockQuery.mock.calls[0];
+    expect(sql).toContain('WHERE "id"=$2');
+    expect(params).toEqual([30, 1]);
+  });
+
+  test('updateWeeks uses parameter placeholder', async () => {
+    await updateWeeks(3, { weight: 2.5 });
+    const [sql, params] = mockQuery.mock.calls[0];
+    expect(sql).toContain('WHERE "id"=$2');
+    expect(params).toEqual([2.5, 3]);
+  });
+});

--- a/server/db/helpers/pregnancy.js
+++ b/server/db/helpers/pregnancy.js
@@ -36,8 +36,10 @@ const getPregnancyByUserId = async (user_id) => {
     FROM pregnancies preg
     JOIN pregnancyweeks pregw ON preg.id = pregw.preg_id
     JOIN weeks ON pregw.week_id = weeks.id
-    WHERE preg.user_id = ${user_id};
+    WHERE preg.user_id = $1;
     `
+    ,
+    [user_id]
   );
   return pregnancies;
 };
@@ -51,14 +53,15 @@ async function updatePregnancies(pregnancyId, fields) {
     let pregnancy;
 
     if (util.dbFields(toUpdate).insert.length > 0) {
+      const { insert, vals } = util.dbFields(toUpdate);
       const { rows } = await client.query(
         `
           UPDATE pregnancies
-          SET ${util.dbFields(toUpdate).insert}
-          WHERE "id"=${pregnancyId}
+          SET ${insert}
+          WHERE "id"=$${vals.length + 1}
           RETURNING *;
         `,
-        Object.values(toUpdate)
+        [...vals, pregnancyId]
       );
       pregnancy = rows[0];
     }

--- a/server/db/helpers/users.js
+++ b/server/db/helpers/users.js
@@ -45,10 +45,10 @@ const updateJournal = async (id, body) => {
     `
     UPDATE users
     SET username = $1, journal = $2
-    WHERE id = ${id}
+    WHERE id = $3
     returning *;
     `,
-    [body.username, body.journal]
+    [body.username, body.journal, id]
   );
   return rows;
 };

--- a/server/db/helpers/weeks.js
+++ b/server/db/helpers/weeks.js
@@ -52,14 +52,15 @@ async function updateWeeks(week_id, fields) {
     let weeks;
 
     if (util.dbFields(toUpdate).insert.length > 0) {
+      const { insert, vals } = util.dbFields(toUpdate);
       const { rows } = await client.query(
         `
           UPDATE weeks
-          SET ${util.dbFields(toUpdate).insert}
-          WHERE "id"=${week_id}
+          SET ${insert}
+          WHERE "id"=$${vals.length + 1}
           RETURNING *;
         `,
-        Object.values(toUpdate)
+        [...vals, week_id]
       );
       weeks = rows[0];
     }

--- a/server/package.json
+++ b/server/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "jest",
     "seed": "node ./db/seed.js",
     "build": "cd ../client && npm run build",
     "production:build": "npm run seed && npm run build ",
@@ -23,5 +23,8 @@
     "morgan": "^1.10.0",
     "nodemon": "^3.0.1",
     "pg": "^8.11.3"
+  },
+  "devDependencies": {
+    "jest": "^29.6.1"
   }
 }


### PR DESCRIPTION
## Summary
- parameterize several database queries
- add Jest unit test scaffolding

## Testing
- `npm test --prefix server` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f936b9bb88323b7878e22167ed204