### PR TITLE
Update HRC link and remove stray text

### DIFF
--- a/client/src/components/StatesRights.jsx
+++ b/client/src/components/StatesRights.jsx
@@ -18,7 +18,7 @@ const StatesRights = () => {
         abortion, trans and GLBQI rights. Need the info?
       </h3>
       <h3>
-        Check out these amazing websites and see how each state "scores":{" "}
+        Check out these amazing websites and see how each state "scores:"
       </h3>
       <h2>
         <a
@@ -31,7 +31,7 @@ const StatesRights = () => {
       </h2>
       <h2>
         <a
-          href="https://https://www.hrc.org/resources/state-scorecards"
+          href="https://www.hrc.org/resources/state-scorecards"
           target="_blank"
           rel="noopener noreferrer"
         >


### PR DESCRIPTION
## Summary
- fix stray text in the StatesRights component
- correct HRC state scorecards link

## Testing
- `npm run lint` *(fails: couldn't find eslint config)*
- `npm run build` *(fails: 403 Forbidden fetching packages)*

------
https://chatgpt.com/codex/tasks/task_e_684f93711f0c8323adfad4ef8b5294c2