### PR TITLE
Load secrets from env

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,13 @@
 # GHP2306-capstone-starter-repo
+
+## Environment Variables
+
+Create a `.env` file inside the `server` directory with the following
+variables:
+
+```
+JWT_SECRET=your_jwt_secret
+COOKIE_SECRET=your_cookie_secret
+```
+
+These values are required for authentication and cookie signing.

--- a/server/secrets.js
+++ b/server/secrets.js
@@ -1,4 +1,6 @@
-const JWT_SECRET = 'pumpkin'
-const COOKIE_SECRET = 'tell everyone'
+const dotenv = require('dotenv')
+dotenv.config({ path: './.env' })
+
+const { JWT_SECRET, COOKIE_SECRET } = process.env
 
 module.exports = { JWT_SECRET, COOKIE_SECRET }


### PR DESCRIPTION
## Summary
- load `JWT_SECRET` and `COOKIE_SECRET` from environment variables
- document required `.env` variables

## Testing
- `npm test --silent` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684f2dc93a7c832394475da94907a649