### PR TITLE
Fix link to HRC state scorecards

### DIFF
--- a/client/src/components/StatesRights.jsx
+++ b/client/src/components/StatesRights.jsx
@@ -31,7 +31,7 @@ const StatesRights = () => {
       </h2>
       <h2>
         <a
-          href="https://https://www.hrc.org/resources/state-scorecards"
+          href="https://www.hrc.org/resources/state-scorecards"
           target="_blank"
           rel="noopener noreferrer"
         >


### PR DESCRIPTION
## Summary
- correct broken link to HRC state scorecards

## Testing
- `npm test` in `server` (fails: no test specified)
- `npm test` in `client` (fails: missing script)

------
https://chatgpt.com/codex/tasks/task_e_684de1a38dcc83239174635b3f1ca562