### PR TITLE
Add journal entries table

### DIFF
--- a/server/db/helpers/journalEntries.js
+++ b/server/db/helpers/journalEntries.js
@@ -1,0 +1,17 @@
+const client = require("../client");
+
+const createJournalEntry = async ({ user_id, content }) => {
+  const {
+    rows: [entry],
+  } = await client.query(
+    `
+        INSERT INTO journal_entries(user_id, content)
+        VALUES ($1, $2)
+        RETURNING *
+    `,
+    [user_id, content]
+  );
+  return entry;
+};
+
+module.exports = { createJournalEntry };

--- a/server/db/seed.js
+++ b/server/db/seed.js
@@ -3,7 +3,8 @@ const { createUser } = require("./helpers/users");
 const { createPregnancy } = require("./helpers/pregnancy");
 const { createPregnancyWeeks } = require("./helpers/pregnancyWeeks");
 const { createWeeks } = require("./helpers/weeks");
-const { users, pregnancies, weeks, pregnancyWeeks } = require("./seedData");
+const { createJournalEntry } = require("./helpers/journalEntries");
+const { users, pregnancies, weeks, pregnancyWeeks, journalEntries } = require("./seedData");
 
 const dropTables = async () => {
   try {
@@ -11,6 +12,7 @@ const dropTables = async () => {
         DROP TABLE IF EXISTS pregnancyWeeks;
         DROP TABLE IF EXISTS weeks;
         DROP TABLE IF EXISTS pregnancies;
+        DROP TABLE IF EXISTS journal_entries;
         DROP TABLE IF EXISTS users;
     `);
     console.log("Dropped Tables");
@@ -27,6 +29,12 @@ const createTables = async () => {
             username VARCHAR(255) UNIQUE NOT NULL,
             password VARCHAR(255) NOT NULL,
             journal text
+        );
+        CREATE TABLE journal_entries(
+            id SERIAL PRIMARY KEY,
+            user_id INTEGER REFERENCES users(id),
+            content TEXT NOT NULL,
+            created_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP
         );
         CREATE TABLE pregnancies(
             id SERIAL PRIMARY KEY,
@@ -77,6 +85,13 @@ const createInitialPregnancyWeeks = async () => {
   }
 };
 
+const createInitialJournalEntries = async () => {
+  console.log("Creating Journal Entries...");
+  for (const entry of journalEntries) {
+    await createJournalEntry(entry);
+  }
+};
+
 const initDb = async () => {
   console.log("init");
   try {
@@ -87,6 +102,7 @@ const initDb = async () => {
     await createInitialPregnancies();
     await createInitialWeeks();
     await createInitialPregnancyWeeks();
+    await createInitialJournalEntries();
     console.log("DB is seeded and ready to go!!");
   } catch (error) {
     console.error(error);

--- a/server/db/seedData.js
+++ b/server/db/seedData.js
@@ -21,4 +21,10 @@ const pregnancyWeeks = [
   { week_id: 2, preg_id: 2 },
   { week_id: 3, preg_id: 3 },
 ];
-module.exports = { users, pregnancies, weeks, pregnancyWeeks };
+const journalEntries = [
+  { user_id: 1, content: "First entry" },
+  { user_id: 2, content: "Excited to start this journey" },
+  { user_id: 3, content: "Feeling great today" },
+];
+
+module.exports = { users, pregnancies, weeks, pregnancyWeeks, journalEntries };


### PR DESCRIPTION
## Summary
- create `journal_entries` table for each user
- add helper to insert journal entries
- seed demo journal entry data

## Testing
- `npm test --silent --prefix server`

------
https://chatgpt.com/codex/tasks/task_e_684de5ca09d08323b7b840fdfe157fc6