### PR TITLE
Implement journal entry routes

### DIFF
--- a/server/api/journal.js
+++ b/server/api/journal.js
@@ -1,10 +1,30 @@
 const router = require("express").Router();
-const { updateJournal } = require("../db/helpers/users");
+const jwt = require("jsonwebtoken");
+const { JWT_SECRET } = process.env;
 
-router.put("/:id", async (req, res, next) => {
+const {
+  createJournalEntry,
+  getEntriesByUserId,
+} = require("../db/helpers/journalEntries");
+
+router.post("/", async (req, res, next) => {
   try {
-    const journal = await updateJournal(req.params.id, req.body);
-    res.send(journal);
+    const token = req.headers.authorization;
+    const { id } = await jwt.verify(token, JWT_SECRET);
+    const { content } = req.body;
+    const entry = await createJournalEntry({ user_id: id, content });
+    res.send(entry);
+  } catch (err) {
+    next(err);
+  }
+});
+
+router.get("/", async (req, res, next) => {
+  try {
+    const token = req.headers.authorization;
+    const { id } = await jwt.verify(token, JWT_SECRET);
+    const entries = await getEntriesByUserId(id);
+    res.send(entries);
   } catch (err) {
     next(err);
   }

--- a/server/db/helpers/journalEntries.js
+++ b/server/db/helpers/journalEntries.js
@@ -1,0 +1,32 @@
+const client = require("../client");
+
+const createJournalEntry = async ({ user_id, content }) => {
+  const {
+    rows: [entry],
+  } = await client.query(
+    `
+        INSERT INTO journalEntries(user_id, content)
+        VALUES ($1, $2)
+        RETURNING *
+    `,
+    [user_id, content]
+  );
+  return entry;
+};
+
+const getEntriesByUserId = async (user_id) => {
+  const { rows } = await client.query(
+    `
+    SELECT * FROM journalEntries
+    WHERE user_id = $1
+    ORDER BY created_at DESC
+    `,
+    [user_id]
+  );
+  return rows;
+};
+
+module.exports = {
+  createJournalEntry,
+  getEntriesByUserId,
+};

--- a/server/db/seed.js
+++ b/server/db/seed.js
@@ -5,9 +5,13 @@ const { createPregnancyWeeks } = require("./helpers/pregnancyWeeks");
 const { createWeeks } = require("./helpers/weeks");
 const { users, pregnancies, weeks, pregnancyWeeks } = require("./seedData");
 
+// helper for journal entries (if seed data is added later)
+// const { createJournalEntry } = require("./helpers/journalEntries");
+
 const dropTables = async () => {
   try {
     await client.query(`
+        DROP TABLE IF EXISTS journalEntries;
         DROP TABLE IF EXISTS pregnancyWeeks;
         DROP TABLE IF EXISTS weeks;
         DROP TABLE IF EXISTS pregnancies;
@@ -27,6 +31,12 @@ const createTables = async () => {
             username VARCHAR(255) UNIQUE NOT NULL,
             password VARCHAR(255) NOT NULL,
             journal text
+        );
+        CREATE TABLE journalEntries(
+            id SERIAL PRIMARY KEY,
+            user_id INTEGER REFERENCES users(id),
+            content TEXT NOT NULL,
+            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
         );
         CREATE TABLE pregnancies(
             id SERIAL PRIMARY KEY,


### PR DESCRIPTION
## Summary
- add journalEntries helper
- create journalEntries table in seeds
- implement `/api/journal` POST and GET

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684de5cca2808323a105f3a9cb3c3e10