### PR TITLE
Add journal entry routes and helpers

### DIFF
--- a/server/api/journal.js
+++ b/server/api/journal.js
@@ -1,5 +1,28 @@
 const router = require("express").Router();
 const { updateJournal } = require("../db/helpers/users");
+const {
+  createJournalEntry,
+  getAllJournalEntries,
+} = require("../db/helpers/journalEntries");
+
+router.get("/", async (req, res, next) => {
+  try {
+    const entries = await getAllJournalEntries();
+    res.send(entries);
+  } catch (err) {
+    next(err);
+  }
+});
+
+router.post("/", async (req, res, next) => {
+  try {
+    const { user_id, text } = req.body;
+    const entry = await createJournalEntry({ user_id, content: text });
+    res.send(entry);
+  } catch (err) {
+    next(err);
+  }
+});
 
 router.put("/:id", async (req, res, next) => {
   try {

--- a/server/db/helpers/__tests__/helpers.test.js
+++ b/server/db/helpers/__tests__/helpers.test.js
@@ -4,6 +4,10 @@ jest.mock('../../client', () => ({ query: mockQuery }));
 const { getPregnancyByUserId, updatePregnancies } = require('../pregnancy');
 const { updateJournal } = require('../users');
 const { updateWeeks } = require('../weeks');
+const {
+  getJournalEntriesByUserId,
+  updateJournalEntry,
+} = require('../journalEntries');
 
 describe('database helper queries', () => {
   beforeEach(() => {
@@ -37,5 +41,20 @@ describe('database helper queries', () => {
     const [sql, params] = mockQuery.mock.calls[0];
     expect(sql).toContain('WHERE "id"=$2');
     expect(params).toEqual([2.5, 3]);
+  });
+
+  test('getJournalEntriesByUserId uses parameter placeholder', async () => {
+    await getJournalEntriesByUserId(7);
+    expect(mockQuery).toHaveBeenCalledWith(
+      expect.stringContaining('WHERE user_id = $1'),
+      [7]
+    );
+  });
+
+  test('updateJournalEntry uses parameter placeholder', async () => {
+    await updateJournalEntry(5, { content: 'entry' });
+    const [sql, params] = mockQuery.mock.calls[0];
+    expect(sql).toContain('WHERE "id"=$2');
+    expect(params).toEqual(['entry', 5]);
   });
 });

--- a/server/db/helpers/journalEntries.js
+++ b/server/db/helpers/journalEntries.js
@@ -1,4 +1,5 @@
 const client = require("../client");
+const util = require("../util");
 
 const createJournalEntry = async ({ user_id, content }) => {
   const {
@@ -14,4 +15,57 @@ const createJournalEntry = async ({ user_id, content }) => {
   return entry;
 };
 
-module.exports = { createJournalEntry };
+const getAllJournalEntries = async () => {
+  const { rows } = await client.query(
+    `SELECT * FROM journal_entries ORDER BY created_at DESC;`
+  );
+  return rows;
+};
+
+const getJournalEntriesByUserId = async (user_id) => {
+  const { rows } = await client.query(
+    `SELECT * FROM journal_entries WHERE user_id = $1 ORDER BY created_at DESC;`,
+    [user_id]
+  );
+  return rows;
+};
+
+async function updateJournalEntry(entryId, fields) {
+  const toUpdate = {};
+  for (let column in fields) {
+    if (fields[column] !== undefined) toUpdate[column] = fields[column];
+  }
+  let entry;
+
+  if (util.dbFields(toUpdate).insert.length > 0) {
+    const { insert, vals } = util.dbFields(toUpdate);
+    const { rows } = await client.query(
+      `
+          UPDATE journal_entries
+          SET ${insert}
+          WHERE "id"=$${vals.length + 1}
+          RETURNING *;
+        `,
+      [...vals, entryId]
+    );
+    entry = rows[0];
+  }
+
+  return entry;
+}
+
+async function deleteJournalEntry(id) {
+  const { rows } = await client.query(
+    'DELETE FROM journal_entries WHERE "id"=$1 RETURNING *',
+    [id]
+  );
+  return rows[0];
+}
+
+module.exports = {
+  createJournalEntry,
+  getAllJournalEntries,
+  getJournalEntriesByUserId,
+  updateJournalEntry,
+  deleteJournalEntry,
+};


### PR DESCRIPTION
## Summary
- expand journal routes with GET and POST handlers
- add helper functions for journal entry CRUD operations
- test the new helpers with Jest

## Testing
- `npm --prefix server test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_688adbe571dc8323b0bd6804b79dd6f8