### PR TITLE
Use environment variables for secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ COOKIE_SECRET=your_cookie_secret
 # DATABASE_URL=postgres://user:password@localhost:5432/queerPregnancyApp
 ```
 
-`PORT` controls which port the Express server runs on. `JWT_SECRET` and `COOKIE_SECRET` are used for authentication.
+`PORT` controls which port the Express server runs on. `JWT_SECRET` and `COOKIE_SECRET` are used for authentication and should be set using environment variables rather than editing `secrets.js`.
 
 ## Development
 

--- a/server/api/utils.js
+++ b/server/api/utils.js
@@ -1,5 +1,6 @@
 const jwt = require('jsonwebtoken')
-const { JWT_SECRET } = require('../secrets')
+require('dotenv').config()
+const { JWT_SECRET } = process.env
 
 const authRequired = (req, res, next) => {
   const token = req.signedCookies.token

--- a/server/db/app.js
+++ b/server/db/app.js
@@ -1,11 +1,10 @@
 const express = require('express')
 const morgan = require('morgan')
 const cookieParser = require('cookie-parser')
-const { COOKIE_SECRET } = require('./secrets')
-const { authRequired } = require('../api/utils')
-const client = require('./db/client')
-
 require('dotenv').config()
+const { COOKIE_SECRET } = process.env
+const { authRequired } = require('../api/utils')
+const client = require('./client')
 
 client.connect()
 
@@ -17,7 +16,7 @@ app.use(cookieParser(COOKIE_SECRET))
 
 app.use(express.json())
 
-app.use('/api', require('./api'))
+app.use('/api', require('../api'))
 
 app.get('/test', authRequired, (req, res, next) => {
   res.send('You are authorized')


### PR DESCRIPTION
## Summary
- document .env variables for jwt and cookie secrets
- update util helper to read JWT secret from environment
- update server app to read cookie secret from environment

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_688ae243b7f48323aee5e19222a9ce1c