### PR TITLE
Add gh-pages deployment scripts

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -8,7 +8,9 @@
     "build": "npm i && vite build",
     "lint": "eslint . --ext js,jsx --report-unused-disable-directives --max-warnings 0",
     "preview": "vite preview",
-    "cypress": "cypress open"
+    "cypress": "cypress open",
+    "predeploy": "npm run build",
+    "deploy": "gh-pages -d dist"
   },
   "dependencies": {
     "dotenv": "^16.3.1",
@@ -24,6 +26,7 @@
     "eslint-plugin-react": "^7.32.2",
     "eslint-plugin-react-hooks": "^4.6.0",
     "eslint-plugin-react-refresh": "^0.4.3",
-    "vite": "^4.4.5"
+    "vite": "^4.4.5",
+    "gh-pages": "^5.0.0"
   }
 }


### PR DESCRIPTION
## Summary
- add `predeploy` and `deploy` scripts
- include `gh-pages` in devDependencies

## Testing
- `npm install --save-dev gh-pages` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_688d03b7273c832396ff36e177f501a1