### PR TITLE
Fix journal entries display

### DIFF
--- a/client/src/components/MyJournal.jsx
+++ b/client/src/components/MyJournal.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 
 // Component displays a form to create a journal entry and lists past entries
 const MyJournal = () => {
@@ -57,7 +57,7 @@ const MyJournal = () => {
           {entries.map((entry) => (
             <div key={entry.id} className="journal-entry">
               <strong>{new Date(entry.created_at).toLocaleDateString()}</strong>
-              <p>{entry.text}</p>
+              <p>{entry.content}</p>
             </div>
           ))}
         </div>


### PR DESCRIPTION
## Summary
- Fix journal page to display each entry's content and its creation date

## Testing
- `npm test` (server)
- `npx eslint src/components/MyJournal.jsx`

------
https://chatgpt.com/codex/tasks/task_e_688d7c2f36308323a279b99b42a5ee8f