### PR TITLE
fix(security): add rate limiting, helmet, secure cookies

### DIFF
--- a/server/api/auth.js
+++ b/server/api/auth.js
@@ -11,6 +11,12 @@ const { token } = require("morgan");
 const router = require("express").Router();
 
 const SALT_ROUNDS = 10;
+const COOKIE_OPTIONS = {
+  sameSite: "strict",
+  httpOnly: true,
+  signed: true,
+  secure: true,
+};
 
 router.get("/", async (req, res, next) => {
   try {
@@ -51,11 +57,7 @@ router.post("/register", async (req, res, next) => {
     const token = jwt.sign(user, JWT_SECRET);
 
     //attaching a cookie to our response using the token that we created
-    res.cookie("token", token, {
-      sameSite: "strict",
-      httpOnly: true,
-      signed: true,
-    });
+    res.cookie("token", token, COOKIE_OPTIONS);
 
     delete user.password;
     // console.log(res)
@@ -87,11 +89,7 @@ router.post("/login", async (req, res, next) => {
       //creating our token
       const token = jwt.sign(user, JWT_SECRET);
       //attaching a cookie to our response using the token that we created
-      res.cookie("token", token, {
-        sameSite: "strict",
-        httpOnly: true,
-        signed: true,
-      });
+      res.cookie("token", token, COOKIE_OPTIONS);
       console.log("token", token);
 
       delete user.password;
@@ -109,11 +107,7 @@ router.post("/login", async (req, res, next) => {
 
 router.post("/logout", async (req, res, next) => {
   try {
-    res.clearCookie("token", {
-      sameSite: "strict",
-      httpOnly: true,
-      signed: true,
-    });
+    res.clearCookie("token", COOKIE_OPTIONS);
     res.send({
       loggedIn: false,
       message: "Logged Out",

--- a/server/index.js
+++ b/server/index.js
@@ -1,5 +1,7 @@
 const express = require("express");
 const app = express();
+const rateLimit = require("express-rate-limit");
+const helmet = require("helmet");
 const cookieParser = require("cookie-parser");
 const dotenv = require("dotenv");
 dotenv.config({ path: "./.env" });
@@ -9,6 +11,13 @@ const path = require("path");
 // init morgan
 const morgan = require("morgan");
 app.use(morgan("dev"));
+app.set("trust proxy", 1);
+app.use(helmet());
+const limiter = rateLimit({
+  windowMs: 15 * 60 * 1000,
+  max: 100,
+});
+app.use(limiter);
 app.use(cookieParser(process.env.COOKIE_SECRET));
 
 // init body-parser

--- a/server/package.json
+++ b/server/package.json
@@ -19,8 +19,10 @@
     "cors": "^2.8.5",
     "dotenv": "^16.3.1",
     "express": "^4.18.2",
+    "express-rate-limit": "^6.7.0",
     "jsonwebtoken": "^9.0.2",
     "morgan": "^1.10.0",
+    "helmet": "^6.0.1",
     "nodemon": "^3.0.1",
     "pg": "^8.11.3"
   },


### PR DESCRIPTION
## Summary
- add helmet and express-rate-limit middleware for security
- secure auth cookies with `secure` flag
- declare helmet and express-rate-limit dependencies

## Testing
- `npm install` *(fails: 403 Forbidden for express-rate-limit)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5f8b9abd08323a1d118de639c5be7