### PR TITLE
Remove sensitive logging

### DIFF
--- a/client/src/components/LoginForm.jsx
+++ b/client/src/components/LoginForm.jsx
@@ -19,7 +19,6 @@ const LoginForm = ({ setUser }) => {
       });
 
       const data = await response.json();
-      console.log(response);
       if (data.ok) {
         if (data.token) {
           localStorage.setItem("token", data.token);

--- a/client/src/components/RegisterForm.jsx
+++ b/client/src/components/RegisterForm.jsx
@@ -19,7 +19,6 @@ const RegisterForm = ({ setUser }) => {
       });
 
       const data = await response.json();
-      console.log(response);
       if (data.ok) {
         if (data.token) {
           localStorage.setItem("token", data.token);

--- a/server/api/auth.js
+++ b/server/api/auth.js
@@ -29,9 +29,7 @@ router.get("/", async (req, res, next) => {
 router.get("/me", async (req, res, next) => {
   try {
     const response = await jwt.verify(req.headers.authorization, JWT_SECRET);
-    console.log("resp1", response);
     const user = await getUserByToken(response.id);
-    console.log("user", user);
     if (!user) {
       throw "not a user";
     }
@@ -44,7 +42,6 @@ router.get("/me", async (req, res, next) => {
 
 router.post("/register", async (req, res, next) => {
   try {
-    console.log(req.body, JWT_SECRET);
     const { username, password } = req.body;
     //hashing the password
     const hashedPassword = await bcrypt.hash(password, SALT_ROUNDS);
@@ -70,10 +67,8 @@ router.post("/register", async (req, res, next) => {
 
 router.post("/login", async (req, res, next) => {
   try {
-    console.log("req.body", req.body);
     const { username, password } = req.body;
     const user = await getUserByUsername(username);
-    console.log("user", user);
 
     if (!user) {
       return res
@@ -82,7 +77,6 @@ router.post("/login", async (req, res, next) => {
     }
 
     const validPassword = await bcrypt.compare(password, user.password);
-    console.log("validPassword", validPassword);
 
     // delete user.password;
     if (validPassword) {
@@ -90,7 +84,6 @@ router.post("/login", async (req, res, next) => {
       const token = jwt.sign(user, JWT_SECRET);
       //attaching a cookie to our response using the token that we created
       res.cookie("token", token, COOKIE_OPTIONS);
-      console.log("token", token);
 
       delete user.password;
       res.send({ user, ok: true, token });

--- a/server/api/utils.js
+++ b/server/api/utils.js
@@ -4,7 +4,9 @@ const { JWT_SECRET } = process.env
 
 const authRequired = (req, res, next) => {
   const token = req.signedCookies.token
-  console.log('Cookie Token:', token)
+  if (process.env.NODE_ENV !== 'production') {
+    console.log('Cookie token length:', token?.length)
+  }
   try {
     jwt.verify(token, JWT_SECRET)
   } catch (error) {


### PR DESCRIPTION
## Summary
- remove debug logging that exposed JWT secret, request data, and tokens
- log only cookie token length in non-production environments
- drop noisy console logging from client auth forms

## Testing
- `npm test` (server)
- `npm test` (client) *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b5fa5cdf648323bee9949782cc4180